### PR TITLE
Dependency update

### DIFF
--- a/logs.log
+++ b/logs.log
@@ -3121,3 +3121,5 @@
 2024-04-17 14:41:43,588 - file - DEBUG - mqtt -- publishing msg ***
 2024-04-17 14:41:43,588 - file - DEBUG - mqtt -- topic: oc2/rsp
 2024-04-17 14:41:43,588 - file - DEBUG - mqtt -- rsp msg: {"headers": {"request_id": "ee5aac85d73c49e4b825f9ebbfc36fea", "created": 1713379303585, "from": "oif-device-priapus-1713378726168"}, "body": {"openc2": {"response": {"status": 200, "results": "query action completed by OIF Device"}}}}
+2025-03-21 12:24:17,849 - file - DEBUG - Debug FILE -- App Started
+2025-03-21 12:24:19,507 - asyncio - DEBUG - Using selector: EpollSelector

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,5 +1,18 @@
 # OpenC2 Device Release Notes
 
+## v2.2.1
+
+Updates made to the following:
+* setuptools==70.0.0 => 77.0.3
+* uvicorn==0.22.0 => 0.34.0
+* fastapi==0.110.0=> 0.115.11
+* pyyaml==6.0.1=> 6.0.2
+* python-benedict==0.31.0 => 0.34.1
+* paho-mqtt==2.0.0 => 2.1.0
+* stix2-validator==3.1.4 => 3.2.0
+* Jinja2==3.1.4=> 3.1.6
+* kestrel-core==1.8 => 1.8.2
+
 ## v2.2.0
 
 * Updated a number of vulnerable dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-kestrel-core==1.8
+kestrel-core==1.8.2
 kestrel-datasource-stixbundle==1.8.0
 kestrel-datasource-stixshifter==1.8.0
 
@@ -6,25 +6,27 @@ kestrel-datasource-stixshifter==1.8.0
 # kestrel-analytics-docke==1.8.0 (probably no need to install; need it if running any analytics in Docker)
 # kestrel-jupyter (installs everything with Jupyter)
 
-Jinja2==3.1.4
+Jinja2==3.1.6
 
+# 7.N.N is available
 stix-shifter==6.2.2
 stix-shifter-utils==6.2.2
+
 stix2-matcher
 stix2-patterns
-stix2-validator==3.1.4
+stix2-validator==3.2.0
 
-paho-mqtt==2.0.0
+paho-mqtt==2.1.0
 toml==0.10.2
 jsonschema
-python-benedict==0.31.0
-pyyaml==6.0.1
-fastapi==0.110.0
-uvicorn==0.22.0
+python-benedict==0.34.1
+pyyaml==6.0.2
+fastapi==0.115.11
+uvicorn==0.34.0
 
 pyopenssl
 
-setuptools==70.0.0
+setuptools==77.0.3
 
 # You may need to run these separately 
 # pip install --upgrade pip


### PR DESCRIPTION
updated for v2.2.1
setuptools==70.0.0 => 77.0.3
uvicorn==0.22.0 => 0.34.0
fastapi==0.110.0=> 0.115.11
pyyaml==6.0.1=> 6.0.2
python-benedict==0.31.0 => 0.34.1
paho-mqtt==2.0.0 => 2.1.0
stix2-validator==3.1.4 => 3.2.0
Jinja2==3.1.4=> 3.1.6
kestrel-core==1.8 => 1.8.2